### PR TITLE
Add C types to generated symbols

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -44,7 +44,7 @@ jobs:
       if: steps.check.outputs.newtag == 'new_tag'
       run: |
         python -m pmdsky_debug_py_generator.main \
-          -i ../pmdsky-debug/symbols \
+          -i ../pmdsky-debug \
           -o ../src \
           -r $RELEASE
       working-directory: generator

--- a/generator/pmdsky_debug_py_generator/main.py
+++ b/generator/pmdsky_debug_py_generator/main.py
@@ -88,7 +88,7 @@ def calculate_out_version(release: str, pptml: dict) -> str:
 )
 @click.option(
     '-i', '--in-path', required=True,
-    help='Input path of the YAML files (usually the symbols/ directory in pmdsky-debug).'
+    help='Input path of the symbol data files (usually the root directory in pmdsky-debug).'
 )
 @click.option(
     '-r', '--release', required=True,

--- a/generator/pmdsky_debug_py_generator/templates/protocol.py.jinja2
+++ b/generator/pmdsky_debug_py_generator/templates/protocol.py.jinja2
@@ -13,6 +13,8 @@ class Symbol(Generic[A, B]):
     # None for most functions. Data fields should generally have a length defined.
     length: B
     description: str
+    # C type of this symbol. Empty string if unknown. None for functions.
+    c_type: Optional[str]
 
     @property
     @no_type_check

--- a/generator/pmdsky_debug_py_generator/templates/region.py.jinja2
+++ b/generator/pmdsky_debug_py_generator/templates/region.py.jinja2
@@ -10,7 +10,8 @@ class {{ region.class_prefix() }}{{ binary.class_name }}Functions:
         {{ fn.addresses[region] | make_relative(binary.loadaddresses[region]) | as_hex }},
         {{ fn.addresses[region] | as_hex }},
         {{ fn.lengths[region] | as_hex }}, 
-        "{{ fn.description | escape_py }}"
+        "{{ fn.description | escape_py }}",
+        None
     )
     {% endfor %}
 
@@ -23,7 +24,8 @@ class {{ region.class_prefix() }}{{ binary.class_name }}Data:
         {{ dt.addresses[region] | make_relative(binary.loadaddresses[region]) | as_hex }},
         {{ dt.addresses[region] | as_hex }},
         {{ dt.lengths[region] | as_hex }}, 
-        "{{ dt.description | escape_py }}"
+        "{{ dt.description | escape_py }}",
+        "{{ dt.type | escape_py }}"
     )
     {% endfor %}
 

--- a/generator/pyproject.toml
+++ b/generator/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pmdsky-debug-py-generator"
-version = "1.0.0"
+version = "1.1.0"
 description = "Generator for pdmsky-debug-py."
 requires-python = ">=3.9"
 license = { text = "MIT" }


### PR DESCRIPTION
With this update, pmdsky-debug-py will include the C type of each defined data symbol, if known. Types are pulled from the C headers.
I tested the new generation and everything seems to work.

Breaking change: The `-i` parameter should now point to the pmdsky-debug root folder, not to the `/symbols` folder.

This change is a prequisite for an API I'm planning to create in skytemple-files. This API will be able to read and write data to the ROM's binaries given a symbol and its containing binary, and type information is required for that.