### PR TITLE
Fix C type regex

### DIFF
--- a/generator/pmdsky_debug_py_generator/loader.py
+++ b/generator/pmdsky_debug_py_generator/loader.py
@@ -25,7 +25,7 @@ from typing import TypeVar, Optional
 import yaml
 
 OVERLAY_REGEX = re.compile(r"overlay(\d+)")
-C_TYPE_REGEX = re.compile(r"(((enum )|(struct ))?[a-z0-9_*]+) ([A-Z0-9_]+)(\[\d+])*;")
+C_TYPE_REGEX = re.compile(r"(((enum )|(struct ))?[a-z0-9_*]+) (([A-Z0-9_]+)(\[\d+])*);")
 PMDSKY_DEBUG_YAML_DIR = "symbols"
 PMDSKY_DEBUG_DATA_HEADERS_DIR = "headers/data"
 


### PR DESCRIPTION
The previous regex would incorrectly capture only the size of the last dimension of array types.