### PR TITLE
Include symbol names in generated symbols

### DIFF
--- a/generator/pmdsky_debug_py_generator/templates/protocol.py.jinja2
+++ b/generator/pmdsky_debug_py_generator/templates/protocol.py.jinja2
@@ -12,6 +12,7 @@ class Symbol(Generic[A, B]):
     absolute_addresses: A
     # None for most functions. Data fields should generally have a length defined.
     length: B
+    name: str
     description: str
     # C type of this symbol. Empty string if unknown. None for functions.
     c_type: Optional[str]

--- a/generator/pmdsky_debug_py_generator/templates/region.py.jinja2
+++ b/generator/pmdsky_debug_py_generator/templates/region.py.jinja2
@@ -9,7 +9,8 @@ class {{ region.class_prefix() }}{{ binary.class_name }}Functions:
     {{ fn.name }} = Symbol(
         {{ fn.addresses[region] | make_relative(binary.loadaddresses[region]) | as_hex }},
         {{ fn.addresses[region] | as_hex }},
-        {{ fn.lengths[region] | as_hex }}, 
+        {{ fn.lengths[region] | as_hex }},
+        "{{ fn.name | escape_py }}",
         "{{ fn.description | escape_py }}",
         None
     )
@@ -23,7 +24,8 @@ class {{ region.class_prefix() }}{{ binary.class_name }}Data:
     {{ dt.name }} = Symbol(
         {{ dt.addresses[region] | make_relative(binary.loadaddresses[region]) | as_hex }},
         {{ dt.addresses[region] | as_hex }},
-        {{ dt.lengths[region] | as_hex }}, 
+        {{ dt.lengths[region] | as_hex }},
+        "{{ dt.name | escape_py }}",
         "{{ dt.description | escape_py }}",
         "{{ dt.type | escape_py }}"
     )


### PR DESCRIPTION
It's a bit annoying that the only way to get the name of a symbol is to read the name of the field that defines it through reflection. Symbols themselves should include their own name as part of the instance, so it's not dependant on where the instance is coming from.